### PR TITLE
Keyword arguments to endpoint calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,10 @@ client = Client.Client("http://localhost:9001/ga4gh/tes/v1/")
 Access the [mock-TES] `/tasks/task-info` endpoint with, e.g.:
 
 ```py
-response = client.GetTaskInfo(
+response = client.getTaskInfo(
     cpu_cores=4,
     ram_gb=8,
     disk_gb=100,
-    preemptible=True,
-    zones=[],
     execution_time_min=10,
 )
 ```
@@ -36,7 +34,7 @@ response = client.GetTaskInfo(
 Access the [mock-TES] `/update-config` endpoint with, e.g.:
 
 ```py
-response = client.UpdateTaskInfoConfig(
+response = client.updateTaskInfoConfig(
     currency="USD",
     time_unit="MINUTES",
     unit_costs={

--- a/tes_client/Client.py
+++ b/tes_client/Client.py
@@ -10,6 +10,7 @@ DEFAULT_CONFIG = {
     "validate_responses": False,
     "headers": None,
     "formats": [DEFAULT_FORMATS["int64"]],
+    "include_missing_properties": True,
 }
 
 
@@ -23,33 +24,25 @@ class Client:
         )
         self.client = self.models.TaskService
 
-    def GetTaskInfo(
+    def getTaskInfo(
         self,
-        cpu_cores,
-        ram_gb,
-        disk_gb,
-        preemptible,
-        zones,
-        execution_time_min
+        timeout=3,
+        **kwargs,
     ):
         # TODO: validate response
         tesResources = self.models.get_model("tesResources")
         request = tesResources(
-            cpu_cores=cpu_cores,
-            ram_gb=ram_gb,
-            disk_gb=disk_gb,
-            preemptible=preemptible,
-            zones=zones,
-            execution_time_min=execution_time_min
+            **kwargs,
         )
-        return self.client.GetTaskInfo(body=request).result()
+        return self.client.GetTaskInfo(body=request).result(timeout=timeout)
 
-    def UpdateTaskInfoConfig(
+    def updateTaskInfoConfig(
         self,
         currency,
         time_unit,
         unit_costs,
     ):
+        # TODO: validate response
         tesTaskInfoConfig = self.models.get_model("tesTaskInfoConfig")
         request = tesTaskInfoConfig(
             currency=currency,


### PR DESCRIPTION
Function `getTaskInfo()` now accepts keyword arguments and fills in missing properties. Parameters `preemptible` and `zones` can now be omitted. However, missing arguments for `cpu_cores`, `ram_gb`, `disk_gb` and `execution_time_min` will lead to errors; needs to be handled in `mock-TES`.